### PR TITLE
fix cle blog post mobile layout issue

### DIFF
--- a/_posts/blog/2022-01-31-color-legend-element.md
+++ b/_posts/blog/2022-01-31-color-legend-element.md
@@ -16,6 +16,8 @@ tags:
 <style>
   color-legend {
     display: block;
+    max-width: min(375px, 100%);
+    overflow-x: auto;
     color: #222;
     margin-bottom: 1rem;
     --cle-border: 1px solid gray;


### PR DESCRIPTION
The `<color-legend>` is wider than the browser viewport on mobile devices. This PR adds some CSS to fix it.