### PR TITLE
Updated about/cv page

### DIFF
--- a/pages/cv.md
+++ b/pages/cv.md
@@ -1,47 +1,36 @@
 ---
 layout: page-fullwidth
 show_meta: false
-title: "Chris L Henrick: Curriculum Vitae"
-meta_description: "Curriculum Vitae or Résumé of Chris Henrick"
+title: "Curriculum Vitae"
+meta_description: "CV of Chris Henrick"
 subheadline: ""
 permalink: "/about/cv/"
 header: no
 ---
 
-My full work and volunteer experience, educational credentials, and technical skills. You may view a shortened version of this CV as a [Google Doc](https://docs.google.com/document/d/1bEH7hsQuHtCw0xqk-Td5uCxiNpvLxXXGF24Rfxw7EIQ/edit?usp=sharing).
+My full work and volunteer experience, educational credentials, and technical skills. View a shortened version of this [CV as a Google Doc](https://docs.google.com/document/d/1bEH7hsQuHtCw0xqk-Td5uCxiNpvLxXXGF24Rfxw7EIQ/edit?usp=sharing).
 
 ## Table of Contents
 
-You may skip ahead to a section of this CV using the following links:
+You may skip ahead to a section of this CV using the following jump links:
 
 - [Professional Experience](#professional-experience)
 - [Volunteer Experience](#volunteer-experience)
 - [Education](#education)
 - [Technical Skills](#technical-skills)
 
----
-## Professional Experience
+<h2 id="professional-experience">Professional Experience</h2>
 
-### Esri  
-**Senior Software Development Engineer**  
-*August, 2022 – present*  
-Remote
+### ESRI StoryMaps
+**Senior Software Development Engineer**<br>
+*August, 2022 – present*<br>
+Redlands, CA / Remote
 
-Senior Software Engineer on the Story Maps team with a focus on feature development relating to interactive geographic maps, (geo) data visualization, and accessibility.
-
-- Contributing front-end engineering to both the [ArcGIS StoryMaps](https://storymaps.arcgis.com/) and [StoryMaps.com](https://storymaps.com) web applications using a tech stack consisting of React, TypeScript, CSS in JS, NextJS, Testing Library, Jest, NodeJS, Yarn, TurboRepo, Webpack, and the ArcGIS JS SDK.
-- Utilizing asynchronous, object oriented, and functional programming methods for application development and version control using Git and Github.
-- Prototyping new features externally from production code using web technology such as HTML, CSS, JavaScript, D3JS, ReactJS, and/or SvelteJS to evaluate usability, technical feasibility, accessibility, integration with live data, and/or responsive design in order to reduce risk and uncertainty in production and gain stakeholder alignment.
-- Collaborating and coordinating with the backend, mobile, and design teams to ensure consistency in product development, user experience, and accessibility.
-- Conducting code reviews to help enforce best practices relating to code quality, automated testing, type safety, writing DRY and reusable code.
-- Mentoring junior developers in tasks such as feature work, bug fixes, accessibility, UI component design, and writing tests.
-- Liaison to the design team advising on digital accessibility, interactive mapping UX and IDX, and technical feasibility of proposed UI designs.
-- Leading the team's Accessibility Working Group to discuss accessibility topics and brainstorm on how to improve digital accessibility in the Story Maps web, tablet, and mobile apps.
-- Coordinating with the Esri Accessibility team to ensure Story Maps adopts and follows best practices for WCAG conformance, accessibility testing (manual and automated), and adequately addressing customer provided feedback on accessibility issues.
+Senior Software Engineer working on [ArcGIS StoryMaps](https://storymaps.arcgis.com/) and [StoryMaps.com](https://storymaps.com) with a focus on feature development relating to interactive geographic maps and geospatial data visualization.
 
 ### University of California, Berkeley
-**Applications Developer 3**  
-*July, 2021 – July, 2022*  
+**Applications Developer 3**<br>
+*July, 2021 – July, 2022*<br>
 Berkeley, CA / Remote
 
 As a team member of the [Geospatial Innovation Facility](http://gif.berkeley.edu) (GIF) at UC Berkeley's Rausser College of Natural Resources I performed front-end Web Development, interactive Data Visualization, and UI/UX Design for [Cal-Adapt](https://cal-adapt.org) and related projects that utilize climate data to address the adaptation and mitigation of climate change for the public and private sectors in California.
@@ -61,8 +50,8 @@ Team Development:
 - Integrated industry sanctioned software development practices such as code reviews, documentation, QA testing, CI/CD, and automated code linting and formatting to make the front-end code for Cal-Adapt more resilient and to foster better collaboration among GIF developers.
 
 ### Google
-**UX Engineer II: Data Visualization**  
-*September, 2018 – June, 2021*  
+**UX Engineer II: Data Visualization**<br>
+*September, 2018 – June, 2021*<br>
 San Francisco, CA
 
 User Experience Engineer focused on prototyping data visualization UI components and developing internal software for the [Google Cloud Platform](https://cloud.google.com/).
@@ -74,8 +63,8 @@ User Experience Engineer focused on prototyping data visualization UI components
 - From August through December of 2020 took part in a [Google.org](https://www.google.org/) fellowship with [Morehouse School of Medicine](https://msm.edu/)'s [Satcher Health Leadership Institute](https://satcherinstitute.org/) to help develop the [Health Equity Tracker](https://healthequitytracker.org/), a web application that uses health related data and data visualization to empower health equity advocates within the U.S.
 
 ### Heavy.AI
-**Data Visualization Engineer**  
-*December, 2017 – September, 2018*  
+**Data Visualization Engineer**<br>
+*December, 2017 – September, 2018*<br>
 San Francisco, CA
 
 Data Visualization Engineer at [Heavy.AI](https://www.heavy.ai/) (formerly OmniSci, MapD), a big data analytics software company. Contributed software development to [Heavy Immerse](https://www.heavy.ai/product/immerse), a web based data visualization and analytics platform, as well as related open-source libraries:
@@ -85,27 +74,27 @@ Data Visualization Engineer at [Heavy.AI](https://www.heavy.ai/) (formerly OmniS
 - [mapd3](https://github.com/heavyai/mapd3)
 
 ### University of California, Berkeley
-**Lecturer**  
-*August, 2017 – December, 2017*  
-Berkeley, CA  
+**Lecturer**<br>
+*August, 2017 – December, 2017*<br>
+Berkeley, CA
 
-Independently developed curriculum for and taught a semester long course, _Interactive Data Visualization with D3JS_, for the [School of Information](https://www.ischool.berkeley.edu/) during the Fall semester of 2017. 
+Independently developed curriculum for and taught a semester long course, _Interactive Data Visualization with D3JS_, for the [School of Information](https://www.ischool.berkeley.edu/) during the Fall semester of 2017.
 
 Through thirteen weekly lectures and fifteen hands on coding assignments, students learned how to create interactive charts, graphs, and geographic maps for display on the web using the popular D3JS data visualization JavaScript library.
 
 ### GreenInfo Network
-**Full Stack Web Developer**  
-*February, 2017 - November, 2017*  
-Oakland, CA  
+**Full Stack Web Developer**<br>
+*February, 2017 - November, 2017*<br>
+Oakland, CA
 
 Full stack web developer with [GreenInfo Network](http://greeninfo.org) specializing in building web applications that utilize geo-visualization with open source GIS and web-mapping software, Javascript, Python, SQL, and PHP.
 - Coordinated with a team of GIS specialists, cartographers, designers, and project managers to produce responsive web applications for clients primarily working in the non-profit, NGO, and government sectors.
 - Assisted the Google Earth Outreach team with creating curated [Google Earth Voyager](https://support.google.com/earth/answer/7365064?hl=en&co=GENIE.Platform%3DDesktop) content for their 2017 relaunch of Google Earth.
 
 ### Stamen Design
-**Design Technologist**  
-*March, 2016 - December, 2016*  
-San Francisco, CA  
+**Design Technologist**<br>
+*March, 2016 - December, 2016*<br>
+San Francisco, CA
 
 One part data wrangler, one part cartographer, and several parts web developer for [Stamen Design](http://stamen.com), a renowned data visualization and design studio.
 - Prototyped and built highly customized web applications with a focus on interactive mapping and data visualization.
@@ -113,16 +102,16 @@ One part data wrangler, one part cartographer, and several parts web developer f
 - Designed and created original tiled basemaps using data from OpenStreetMap and Natural Earth, with technologies such as Make, PostGIS, CartoCSS, and Mapnik.
 
 ### Radish Lab
-**Web Developer**  
-*May, 2015 - April 2016*  
-Brooklyn, NY  
+**Web Developer**<br>
+*May, 2015 - April 2016*<br>
+Brooklyn, NY
 
-Consulted with [Radish Lab](http://radishlab.com/), a certified B Corporation, web and graphic design studio, with creating interactive data-visualizations and professionally designed web sites for non-profits and cultural institutions such as [MAS](http://mas.org/). 
+Consulted with [Radish Lab](http://radishlab.com/), a certified B Corporation, web and graphic design studio, with creating interactive data-visualizations and professionally designed web sites for non-profits and cultural institutions such as [MAS](http://mas.org/).
 - Duties include agile front-end web-development using modern web technologies such as jQuery, Node.JS, D3.JS, Wordpress, CARTO, and Github.
 
 ### Chris Henrick Cartography
-**Web Developer, Cartographer**  
-*June, 2010 - March 2016*  
+**Web Developer, Cartographer**<br>
+*June, 2010 - March 2016*<br>
 San Francisco, CA
 
 Consulted for a diverse range of clients in web development, print cartography, and geospatial data analysis.
@@ -130,8 +119,8 @@ Consulted for a diverse range of clients in web development, print cartography, 
 - Former clients include [Rebecca Solnit](http://rebeccasolnit.net/), [Stamen Design](http://stamen.com/), [Radish Lab](http://radishlab.com/), Pratt's [Spatial Analysis and Visualization Initiative](https://www.pratt.edu/pratt-research-and-centers/spatial-analysis-visualization-initiative/), [The Skyscraper Museum](http://skyscraper.org/), [The Oakland Museum of California](http://museumca.org/), and [Avalon Travel Publishing](http://avalontravelbooks.com/).
 
 ### CARTO
-**Geospatial Developer Intern**  
-*March, 2014 - October, 2014*   
+**Geospatial Developer Intern**<br>
+*March, 2014 - October, 2014*<br>
 New York, NY
 
 Assisted [CARTO](https://carto.com/) with improving their web-based geospatial visualization platform:
@@ -141,9 +130,9 @@ Assisted [CARTO](https://carto.com/) with improving their web-based geospatial v
 - Contributed to technical documentation of the CARTO platform.
 
 ### Avalon Travel Publishing
-**Lead Cartographer**  
-*February, 2012 - May, 2013*  
-Berkeley, CA  
+**Lead Cartographer**<br>
+*February, 2012 - May, 2013*<br>
+Berkeley, CA
 
 Assisted [Avalon Travel](http://avalontravelbooks.com/)'s in-house Cartography Studio with creating new maps and updating existing maps for printed and ebook travel guide series including titles such as [Moon Handbooks](http://moon.com/), [Rick Steve's](https://www.ricksteves.com/), and [Let's Go](http://www.letsgo.com/).
 
@@ -156,8 +145,8 @@ Assisted [Avalon Travel](http://avalontravelbooks.com/)'s in-house Cartography S
 - Designed and structured a spatial data file server.
 
 ### GreenInfo Network
-**GIS Specialist / Cartographer Intern**  
-*Summer, 2010 and Spring, 2011*  
+**GIS Specialist / Cartographer Intern**<br>
+*Summer, 2010 and Spring, 2011*<br>
 San Francisco, CA
 
 Assisted [GreenInfo Nework](http://www.greeninfo.org/) with its mission of providing quality and affordable GIS analysis and cartographic products to public interest groups and governmental organizations.
@@ -169,8 +158,8 @@ Assisted [GreenInfo Nework](http://www.greeninfo.org/) with its mission of provi
 - Contributed outreach to various California land trusts for the California Protected Areas Database (CPAD).
 
 ### Steve Spindler Cartography
-**Cartographer Intern**  
-*Fall, 2009*  
+**Cartographer Intern**<br>
+*Fall, 2009*<br>
 Philadelphia, PA
 
 Aided Cartographer [Steve Spindler](http://www.bikemap.com/) in creating production print maps for the Pennsylvania cross-state bicycle touring route S.
@@ -179,42 +168,41 @@ Aided Cartographer [Steve Spindler](http://www.bikemap.com/) in creating product
 - Utilized Google Maps, Earth, and Docs to perform research and KML point data acquisition relating to bicycle touring.
 
 ### The Delaware Valley Regional Planning Commission
-**Planning Intern**  
-*Spring, 2008*  
+**Planning Intern**<br>
+*Spring, 2008*<br>
 Philadelphia, PA
 
 Assisted [DVRPC](http://www.dvrpc.org/)'s Office of Transit, Bicycle, and Pedestrian Planning in implementing projects related to transit, pedestrian, and bicycle planning in the greater metropolitan Philadelphia area. Participated in tasks such as survey field-work, road safety audits, data scrubbing and aggregation, bicycle route mapping, and power point presentations.
 
------
-## Volunteer Experience:
+<h2 id="volunteer-experience">Volunteer Experience:</h2>
 
 ### Anti-Eviction Mapping Project
-**Web Developer**  
-*February, 2020 – July, 2020*  
+**Web Developer**<br>
+*February, 2020 – July, 2020*<br>
 Remote
 
 Contributed front end web development and cartographic design to the [COVID-19 Emergency Tenants Protections Map]({{site.url}}{{site.baseurl}}/work/aemp-covid-19-tenant-protections-map.html). Worked with a collective of AEMP volunteers to design and develop the project during the start of the COVID-19 pandemic through the summer to map legislation at varying levels of government (and the lack thereof) aimed at protecting tenants from eviction due to pandemic related issues such as loss of employment and illness.
 
 ### Maptime NYC
-**Co-Organizer**  
-*January, 2013 - June, 2016*  
-New York, NY  
+**Co-Organizer**<br>
+*January, 2013 - June, 2016*<br>
+New York, NY
 
 Assisted with organizing and hosting the [Maptime New York City chapter](http://www.meetup.com/Maptime-NYC/). Maptime's goal is to create a safe space for non-experts to learn about GIS, cartography, and web-mapping.
 
 ### ASIAN Inc.
-**GIS Specialist Volunteer**  
-*November, 2009 - July, 2010*  
-San Francisco, CA  
+**GIS Specialist Volunteer**<br>
+*November, 2009 - July, 2010*<br>
+San Francisco, CA
 
 Performed spatial data analysis and visualization to support [ASIAN Inc](http://www.asianinc.org/)'s goals of improving economic and housing opportunities for low income Asian Americans in the San Francisco Bay Area.
 Consulted with GreenInfo Network on best practices for GIS analysis and data visualization of census and in-house demographic data.
 
------
-## Education
+
+<h2 id="education">Education</h2>
 
 ### Storytelling With Data
-**SWD Ten Week Course Certificate**  
+**SWD Ten Week Course Certificate**<br>
 Remote
 
 Completed [Storytelling With Data](https://www.storytellingwithdata.com/)'s ten week course in June, 2021. The primary areas of concentration of this course were:
@@ -228,8 +216,8 @@ Completed [Storytelling With Data](https://www.storytellingwithdata.com/)'s ten 
 The final project for this course was a ten minute presentation on a topic of the participant's choosing. Mine was on the [Digital Divide](https://docs.google.com/presentation/d/1IFXkuGSwGduACZhJ_qy3FRrSBz9bN9GdoMKnDC1mRFM/edit?usp=sharing). Learn more about the course in a [blog post](/swd-ten-week-course/) I wrote about it.
 
 ### Parsons, The New School For Design
-**Master of Fine Art in Design and Technology.**  
-New York, NY  
+**Master of Fine Art in Design and Technology.**<br>
+New York, NY<br>
 GPA 3.91
 
 MFA Thesis: [Am I Rent Stabilized?]({{site.url}}{{site.baseurl}}/work/am-i-rent-stabilized.html), an interactive web-app about rent-stabilization in New York City.
@@ -240,45 +228,43 @@ Areas of focus in [MFA DT](http://www.newschool.edu/parsons/mfa-design-technolog
 - Taught a two day workshop on NodeJS to the incoming class of Parsons MS in Data Visualization class of 2015.
 
 ### U.C. Berkeley Extension
-**Graphic Design Certificate Program**  
+**Graphic Design Certificate Program**<br>
 San Francisco, CA
 
 Areas of concentration include graphic design and typography.
 
 ### Temple University
-**Bachelor of Arts in Geography and Urban Studies.**  
-Philadelphia, PA  
-GPA 3.77, graduated Magna Cum Laude.  
+**Bachelor of Arts in Geography and Urban Studies.**<br>
+Philadelphia, PA<br>
+GPA 3.77, graduated Magna Cum Laude.
 
 Member of Gamma Theta Upsilon, National Honors Society for Geography.
 Recipient of the Henry N. Michael Prize in Geography and Urban Studies.
 
 ### University of the Arts
-**Fine Art: Print Making and Drawing**  
-Philadelphia, PA  
-GPA 3.49  
+**Fine Art: Print Making and Drawing**<br>
+Philadelphia, PA<br>
+GPA 3.49
 
 Studies included drawing, print making, painting, mixed media, and graphic design.
 
------
-## Technical Skills
+<h2 id="technical-skills">Technical Skills</h2>
 
-- TypeScript and JavaScript (ES6+)
-- JavaScript front-end frameworks: React, Angular, Vue, Lit, Svelte
-- JavaScript module bundlers: Webpack, Rollup, Parcel, Vite
-- NodeJS development and the NPM ecosystem
-- Data Visualization using D3JS, Vega / VegaLite, Observable
-- Interactive web mapping and geospatial visualization using Leaflet, MapBoxGLJS, ArcGIS JS SDK, d3-geo
-- CSS, CSS PreProcessors (SCSS, PostCSS), CSS in JS
-- Web Standards: HTML, SVG, ARIA, JSON, HTTP, web browser APIs, Web Components
-- Web Accessibility and screen reader software (Semantic HTML, ARIA, WCAG, VoiceOver, NVDA, JAWS)
-- Version control using Git & Github
-- Command Line Interface (Unix, Bash)
+- JavaScript (ES6+)
+- TypeScript
+- JavaScript Frameworks: React, Angular, Vue, Lit, Svelte
+- JavaScript Module Bundlers (Webpack, Rollup, Parcel, Vite)
+- NodeJS and NPM
+- Data Visualization: D3JS, MapBoxGLJS, Leaflet, Vega / VegaLite
+- CSS and CSS PreProcessors (SCSS, PostCSS)
+- Web Standards (HTML, SVG, ARIA, JSON, HTTP, Browser APIs)
+- Web Accessibility (Semantic HTML, WCAG, Assistive Technology testing)
+- Git & Github
 - SQL (PostgreSQL, SQLite)
-- Geographic Information Systems software (QGIS, PostGIS, GDAL)
+- Geographic Information Systems (QGIS, PostGIS, GDAL)
 - Python (2.x, 3.x)
 - Jupyter Notebooks, Pandas, Geo Pandas, Altair
 - Cloud Computing (AWS, GCP, Digital Ocean)
-- CARTO platform, JavaScript SDK, & API's  
+- CARTO platform, JavaScript SDK, & API's
 - Design software: Figma, Sketch, Adobe Illustrator
 - MAPublisher (GIS & Cartography plug-in for Adobe Illustrator)


### PR DESCRIPTION
Small updates to the CV page:

- use `<br>`s so that markdown formatting does not break layout
- update some info (technical skills, etc.)
- shorten up page title and description